### PR TITLE
Add optional debug logging to chessbridge

### DIFF
--- a/chessbridge.py
+++ b/chessbridge.py
@@ -1,6 +1,13 @@
+import os
 import serial
 import sys
 import threading
+
+RED = "\033[31m"
+GREEN = "\033[32m"
+RESET = "\033[0m"
+
+DEBUG = os.getenv("CHESSBRIDGE_DEBUG") == "1"
 
 ser = serial.Serial('COM15', 115200, timeout=1)  # Port anpassen!
 
@@ -8,7 +15,11 @@ def read_from_pico():
     while True:
         line = ser.readline().decode().strip()
         if line:
-            print(line, flush=True)
+            sys.stdout.write(line + "\n")
+            sys.stdout.flush()
+            if DEBUG:
+                sys.stderr.write(f"{GREEN}Pico → GUI: {line}{RESET}\n")
+                sys.stderr.flush()
 
 threading.Thread(target=read_from_pico, daemon=True).start()
 
@@ -17,6 +28,9 @@ while True:
         line = sys.stdin.readline()
         if not line:
             break
+        if DEBUG:
+            sys.stderr.write(f"{RED}GUI → Pico: {line.rstrip()}{RESET}\n")
+            sys.stderr.flush()
         ser.write(line.encode())
     except KeyboardInterrupt:
         break


### PR DESCRIPTION
## Summary
- add ANSI color constants and optional debug flag
- log Pico ↔ GUI communication with colored stderr messages

## Testing
- `python -m py_compile chessbridge.py`
- `CHESSBRIDGE_DEBUG=1 python chessbridge.py` *(fails: could not open port COM15)*

------
https://chatgpt.com/codex/tasks/task_e_689734d009b8832c90728c9a8290def1